### PR TITLE
Adding persistence with doobie and in-memory database

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,10 +65,15 @@ val commonSettings = Seq(
 
     // the strategy used for translating lambdas into JVM code.
     // The current standard is "inline" but they're moving towards "method."
-    "-Ydelambdafy:method"
+    "-Ydelambdafy:method",
+
+    // Improved type inference via the fix for SI-2712:
+    // https://github.com/scala/bug/issues/2712
+    "-Ypartial-unification"
   ),
   scalacOptions in (Compile, console) ~= (_.filterNot(_ == "-Xlint")),
-  scalacOptions in (Compile, console) ~= (_.filterNot(_ == "-Ywarn-unused-import"))
+  scalacOptions in (Compile, console) ~= (_.filterNot(_ == "-Ywarn-unused-import")),
+  scalacOptions in (Test) ~= (_.filter(_ == "-Ywarn-unused-import"))
 )
 
 addCommandAlias("migrate", ";flyway/flywayMigrate")
@@ -87,6 +92,8 @@ lazy val arrow = (project in file("arrow"))
 lazy val flyway = (project in file("flyway"))
   .settings(commonSettings)
   .enablePlugins(FlywayPlugin)
+  .dependsOn(
+    testkit % "test->test;test->compile;compile->compile")
   .settings(libraryDependencies ++= Dependencies.flyway)
 
 lazy val domain = Project("domain", file("domain"))
@@ -97,6 +104,7 @@ lazy val mysql = Project("mysql", file("mysql"))
   .settings(commonSettings)
   .dependsOn(
     domain % "test->test;test->compile;compile->compile",
+    flyway % "test->test;test->compile;compile->compile",
     testkit % "test->test;test->compile;compile->compile")
   .settings(libraryDependencies ++= Dependencies.mysql)
 

--- a/flyway/src/main/scala/com/gilesc/mynab/InMemoryDatabase.scala
+++ b/flyway/src/main/scala/com/gilesc/mynab/InMemoryDatabase.scala
@@ -4,21 +4,25 @@ package mynab
 import com.gilesc.mynab.testkit.TestCase
 
 abstract class InMemoryDatabase extends TestCase {
-
   private[this] def migrateDatabase(): Unit = {
     import org.flywaydb.core.Flyway
+
+    case class DatabaseConfig(
+      driver: String,
+      url: String,
+      username: String,
+      password: String
+    )
+
+    val config = pureconfig.loadConfigOrThrow[DatabaseConfig]("mynab.database")
     val flyway = new Flyway()
-    lazy val databaseUrl = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1"
-    lazy val databaseUser = "sa"
-    lazy val databasePassword = ""
 
     flyway.setLocations("classpath:db/migration")
-
-    flyway.setDataSource(databaseUrl, databaseUser, databasePassword)
-
+    flyway.setDataSource(config.url, config.username, config.password)
     flyway.migrate()
 
     ()
   }
+
   migrateDatabase()
 }

--- a/flyway/src/main/scala/com/gilesc/mynab/InMemoryDatabase.scala
+++ b/flyway/src/main/scala/com/gilesc/mynab/InMemoryDatabase.scala
@@ -1,0 +1,24 @@
+package com.gilesc
+package mynab
+
+import com.gilesc.mynab.testkit.TestCase
+
+abstract class InMemoryDatabase extends TestCase {
+
+  private[this] def migrateDatabase(): Unit = {
+    import org.flywaydb.core.Flyway
+    val flyway = new Flyway()
+    lazy val databaseUrl = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1"
+    lazy val databaseUser = "sa"
+    lazy val databasePassword = ""
+
+    flyway.setLocations("classpath:db/migration")
+
+    flyway.setDataSource(databaseUrl, databaseUser, databasePassword)
+
+    flyway.migrate()
+
+    ()
+  }
+  migrateDatabase()
+}

--- a/mysql/src/main/resources/application.conf
+++ b/mysql/src/main/resources/application.conf
@@ -1,0 +1,8 @@
+mynab {
+  database {
+    driver = "com.mysql.jdbc.Driver"
+    url = "jdbc:mysql://localhost:3306/typelevel"
+    username = "root"
+    password = "root"
+  }
+}

--- a/mysql/src/main/scala/com/gilesc/mynab/repository/UserRepository.scala
+++ b/mysql/src/main/scala/com/gilesc/mynab/repository/UserRepository.scala
@@ -1,0 +1,67 @@
+package com.gilesc
+package mynab
+package repository
+
+import cats.effect.Async
+import cats.syntax.applicativeError._
+import doobie.free.connection.ConnectionIO
+import doobie.implicits._
+import doobie.util.invariant.UnexpectedEnd
+import doobie.util.query.Query0
+import doobie.util.transactor.Transactor
+
+case class DatabaseConfig(
+  driver: String,
+  url: String,
+  username: String,
+  password: String
+)
+
+object DatabaseConfig {
+  // TODO: This goes away. Just here for getting everything setup
+  type UserDTO = (Int, String, String)
+
+  def apply(path: String = "mynab.database"): DatabaseConfig =
+    pureconfig.loadConfigOrThrow[DatabaseConfig](path)
+}
+
+class Email(val value: String) extends AnyVal
+class UserName(val value: String) extends AnyVal
+case class User(username: UserName, email: Email)
+
+trait UserRepository[F[_]] {
+  def findUser(username: UserName): F[Option[User]]
+}
+
+class MysqlUserRepository[F[_] : Async](
+  xa: Transactor[F]
+) extends UserRepository[F] {
+  import DatabaseConfig._
+
+  implicit class UserConversions(dto: UserDTO) {
+    def toUser: User = User(
+      username = new UserName(dto._2),
+      email = new Email(dto._3)
+    )
+  }
+
+  def userQuery(username: UserName): Query0[UserDTO] = {
+    println("SELECT WHERE USERNAME: " + username.value)
+    val query = sql"SELECT * FROM api_user WHERE username=${username.value}".query[UserDTO]
+    println("QUERY: " + query)
+    query
+  }
+
+  override def findUser(username: UserName): F[Option[User]] = {
+    val userStatement: ConnectionIO[UserDTO] = userQuery(username).unique
+
+    // You might have more than one query involving joins. In such case a for-comprehension would be better
+    val program: ConnectionIO[User] = userStatement.map(_.toUser)
+
+    program.map(Option.apply).transact(xa).recoverWith {
+      case UnexpectedEnd => Async[F].delay(None) // In case the user is not unique in your db. Check out Doobie's docs.
+    }
+  }
+
+}
+

--- a/mysql/src/test/resources/application.conf
+++ b/mysql/src/test/resources/application.conf
@@ -1,0 +1,8 @@
+mynab {
+  database {
+    driver = "org.h2.Driver"
+    url ="jdbc:h2:mem:test;DB_CLOSE_DELAY=-1"
+    username = "sa"
+    password = ""
+  }
+}

--- a/mysql/src/test/scala/com/gilesc/mynab/repository/UserRepositoryQuerySpec.scala
+++ b/mysql/src/test/scala/com/gilesc/mynab/repository/UserRepositoryQuerySpec.scala
@@ -1,0 +1,49 @@
+package com.gilesc
+package mynab
+package repository
+
+import com.gilesc.mynab.testkit.TestCase
+import org.scalatest.{Assertions, FunSuite}
+import doobie._
+import doobie.implicits._
+import doobie.scalatest._
+import doobie.util.transactor.Transactor
+import doobie.util.transactor.Strategy
+import doobie.h2._
+import doobie.h2.implicits._
+import cats._
+import cats.data._
+import cats.effect.{Async, IO}
+import cats.implicits._
+
+class UserRepositoryQuerySpec extends InMemoryDatabase with IOChecker {
+  import DatabaseConfig._
+
+  type UserDTO = (Int, String, String)
+  val config = DatabaseConfig()
+  override def transactor = Transactor.fromDriverManager[IO](
+    config.driver,
+    config.url,
+    config.username,
+    config.password)
+
+  private val userRepo = new MysqlUserRepository[IO](transactor)
+
+  behavior of "User Repository"
+  it should "let me get a user" in {
+    def insert(name: String, email: String): Update0 =
+      sql"insert into api_user (username, email) values ($name, $email)".update
+
+//    val userMock = (1, "gvolpe", "forget")
+//    val cs: ConnectionIO[(Int, String, String)] = FC.delay(userMock)
+//    val result = cs.transact(transactor).unsafeRunSync()
+
+    val username = new UserName("gvolpe")
+    insert(username.value, "email").run.transact(transactor).unsafeRunSync
+    val user = userRepo.userQuery(username)
+    println("PRINTING USER: " + user.list.transact(transactor).unsafeRunSync())
+    val result = user.list.transact(transactor)
+    println(result)
+  }
+}
+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,7 +59,6 @@ object Dependencies {
   def cats(m: String) = "org.typelevel" %% s"cats-$m" % "1.0.1"
   def logbackClassic = "ch.qos.logback"  %  "logback-classic" % "1.1.3"
   def logging = "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"
-  // def config = "com.typesafe" % "config" % "1.3.1"
   def config = "com.github.pureconfig" %% "pureconfig" % "0.8.0"
   def scalatest(scope: String) = "org.scalatest" %% "scalatest" % "3.0.0" % scope
   def finchModules(m: String) = "com.github.finagle" %% s"finch-$m" % "0.13.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,9 +4,10 @@ import Keys._
 object Dependencies {
 
   lazy val core = Seq(
-    cats
+    cats("core")
     ,scalatest("test")
     ,logging
+    ,config
   )
 
   lazy val arrow = core ++ Seq()
@@ -16,7 +17,7 @@ object Dependencies {
   lazy val service = core ++ Seq()
 
   lazy val mysql = Seq(
-    cats
+    cats("core")
     ,scalatest("test")
     ,mysqlConnectorJava
     ,h2database
@@ -48,18 +49,21 @@ object Dependencies {
   )
 
   lazy val testkit = Seq(
-    "org.scalatest" %% "scalatest" % "3.0.0"
+    "org.scalatest" %% "scalatest" % "3.0.4",
+    "org.scalacheck" %% "scalacheck" % "1.13.4"
   )
 
   // --------------------
   //   Libraries
   // --------------------
-  def cats = "org.typelevel" %% "cats" % "0.9.0"
+  def cats(m: String) = "org.typelevel" %% s"cats-$m" % "1.0.1"
   def logbackClassic = "ch.qos.logback"  %  "logback-classic" % "1.1.3"
   def logging = "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"
+  // def config = "com.typesafe" % "config" % "1.3.1"
+  def config = "com.github.pureconfig" %% "pureconfig" % "0.8.0"
   def scalatest(scope: String) = "org.scalatest" %% "scalatest" % "3.0.0" % scope
   def finchModules(m: String) = "com.github.finagle" %% s"finch-$m" % "0.13.1"
-  def circe(m: String) = "io.circe" %% s"circe-$m" % "0.8.0"
+  def circe(m: String) = "io.circe" %% s"circe-$m" % "0.9.0"
 
   // Security
   def bcrypt = "org.mindrot" % "jbcrypt" % "0.3m"
@@ -68,12 +72,12 @@ object Dependencies {
   def akkaHttp(m: String) = "com.typesafe.akka" %% s"akka-$m" % "10.0.9"
   def akkaHttpTestKit() = "com.typesafe.akka" %% "akka-http-testkit" % "10.0.9" % Test
   def httpSession = "com.softwaremill.akka-http-session" %% "core" % "0.5.0"
-  def akkaHttpCirce = "de.heikoseeberger" %% "akka-http-circe" % "1.17.0"
+  def akkaHttpCirce = "de.heikoseeberger" %% "akka-http-circe" % "1.19.0-M3"
 
   // Database
-  def flywayCore = "org.flywaydb" % "flyway-core" % "4.0"
+  def flywayCore = "org.flywaydb" % "flyway-core" % "4.2.0"
   def h2database = "com.h2database"  %  "h2" % "1.4.191"
-  def doobie(m: String) = "org.tpolecat" %% s"doobie-$m-cats" % "0.4.4"
+  def doobie(m: String) = "org.tpolecat" %% s"doobie-$m" % "0.5.0-M11"
 
   // NOTE: plugins.sbt has the same version of mysql-connector-java.
   //       Please keep these two versions in sync.


### PR DESCRIPTION
Doobie integration for persistence and an in memory database testcase
for use with unit testing. The InMemoryDatabase allows for H2 database
with migrations (based on the flyway migrations used in the main
application)

The downside of this is it creates an interesting dependency chain in
the build and potential downsides is now there is 1 test database for
all unit tests.